### PR TITLE
Add remote inference server

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ python -m anylabeling.server.api
 ```
 
 On the client, set the environment variable `XANYLABELING_REMOTE_API` to the server URL (e.g. `http://server:8000`) before launching the application. All predictions will then be executed remotely.
+You can also configure the address from **Tool → Remote Server** in the GUI.
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ https://github.com/user-attachments/assets/52cbdb5d-cc60-4be5-826f-903ea4330ca8
 - Enable import/export for formats like COCO, VOC, YOLO, DOTA, MOT, MASK, PPOCR, VLM-R1.
 - Handles tasks like `classification`, `detection`, `segmentation`, `caption`, `rotation`, `tracking`, `estimation`, `ocr` and so on.
 - Supports diverse annotation styles: `polygons`, `rectangles`, `rotated boxes`, `circles`, `lines`, `points`, and annotations for `text detection`, `recognition`, and `KIE`.
+- Supports remote inference via REST API when `XANYLABELING_REMOTE_API` is set.
 
 
 ### Model library
@@ -128,6 +129,15 @@ https://github.com/user-attachments/assets/52cbdb5d-cc60-4be5-826f-903ea4330ca8
 - [Counting](./examples/counting/)
   - [GeCo](./examples/counting/geco/README.md)
 
+## Running as a server
+
+Start the API service on the remote machine:
+
+```bash
+python -m anylabeling.server.api
+```
+
+On the client, set the environment variable `XANYLABELING_REMOTE_API` to the server URL (e.g. `http://server:8000`) before launching the application. All predictions will then be executed remotely.
 
 ## Contact
 

--- a/anylabeling/configs/xanylabeling_config.yaml
+++ b/anylabeling/configs/xanylabeling_config.yaml
@@ -150,6 +150,9 @@ shortcuts:
   auto_run: Ctrl+M
   loop_thru_labels: Ctrl+Shift+N
 
+# Remote inference
+remote_api_url: null
+
 # Auto labeling
 custom_models: []
 

--- a/anylabeling/resources/translations/en_US.ts
+++ b/anylabeling/resources/translations/en_US.ts
@@ -123,6 +123,24 @@ Results have been saved to:
     </message>
 </context>
 <context>
+    <name>RemoteServerDialog</name>
+    <message>
+        <location filename="../../views/labeling/widgets/remote_server_dialog.py" line="22"/>
+        <source>Set Remote Server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../views/labeling/widgets/remote_server_dialog.py" line="26"/>
+        <source>Enter remote server URL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../views/labeling/widgets/remote_server_dialog.py" line="28"/>
+        <source>e.g. http://host:8000</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AboutDialog</name>
     <message>
         <location filename="../../views/labeling/widgets/about_dialog.py" line="114"/>
@@ -2469,6 +2487,16 @@ Reset the label as {}.</source>
     <message>
         <location filename="../../views/labeling/label_widget.py" line="705"/>
         <source>Manage Group ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../views/labeling/label_widget.py" line="708"/>
+        <source>&amp;Remote Server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../views/labeling/label_widget.py" line="708"/>
+        <source>Configure remote inference server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/anylabeling/resources/translations/zh_CN.ts
+++ b/anylabeling/resources/translations/zh_CN.ts
@@ -124,6 +124,24 @@ Results have been saved to:
     </message>
 </context>
 <context>
+    <name>RemoteServerDialog</name>
+    <message>
+        <location filename="../../views/labeling/widgets/remote_server_dialog.py" line="22"/>
+        <source>Set Remote Server</source>
+        <translation>设置远程服务器</translation>
+    </message>
+    <message>
+        <location filename="../../views/labeling/widgets/remote_server_dialog.py" line="26"/>
+        <source>Enter remote server URL:</source>
+        <translation>输入远程服务器地址：</translation>
+    </message>
+    <message>
+        <location filename="../../views/labeling/widgets/remote_server_dialog.py" line="28"/>
+        <source>e.g. http://host:8000</source>
+        <translation>例如 http://host:8000</translation>
+    </message>
+</context>
+<context>
     <name>AboutDialog</name>
     <message>
         <location filename="../../views/labeling/widgets/about_dialog.py" line="114"/>
@@ -2551,6 +2569,16 @@ Reset the label as {}.</source>
         <location filename="../../views/labeling/label_widget.py" line="705"/>
         <source>Manage Group ID</source>
         <translation>管理群组编号</translation>
+    </message>
+    <message>
+        <location filename="../../views/labeling/label_widget.py" line="708"/>
+        <source>&amp;Remote Server</source>
+        <translation>远程服务器</translation>
+    </message>
+    <message>
+        <location filename="../../views/labeling/label_widget.py" line="708"/>
+        <source>Configure remote inference server</source>
+        <translation>配置远程推理服务器</translation>
     </message>
     <message>
         <location filename="../../views/labeling/label_widget.py" line="1197"/>

--- a/anylabeling/server/__init__.py
+++ b/anylabeling/server/__init__.py
@@ -1,0 +1,2 @@
+"""Server components for remote inference."""
+

--- a/anylabeling/server/api.py
+++ b/anylabeling/server/api.py
@@ -1,0 +1,60 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import numpy as np
+import cv2
+import base64
+from typing import Optional
+
+from anylabeling.services.auto_labeling.model_manager import ModelManager
+
+app = FastAPI()
+
+model_manager = ModelManager()
+
+class PredictRequest(BaseModel):
+    model: str
+    image: str
+    filename: Optional[str] = None
+    text_prompt: Optional[str] = None
+    run_tracker: bool = False
+
+class PredictResponse(BaseModel):
+    shapes: list
+    replace: bool = True
+    description: str = ""
+
+@app.post("/predict", response_model=PredictResponse)
+def predict(req: PredictRequest):
+    # Load model if necessary
+    if (
+        model_manager.loaded_model_config is None
+        or model_manager.loaded_model_config.get("name") != req.model
+    ):
+        model_id = None
+        for i, cfg in enumerate(model_manager.model_configs):
+            if cfg.get("name") == req.model:
+                model_id = i
+                break
+        if model_id is None:
+            return {"shapes": [], "replace": True, "description": "model not found"}
+        model_manager._load_model(model_id)
+
+    img_bytes = base64.b64decode(req.image)
+    img_array = np.frombuffer(img_bytes, dtype=np.uint8)
+    image = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+
+    result = model_manager.predict_shapes(
+        image,
+        filename=req.filename,
+        text_prompt=req.text_prompt,
+        run_tracker=req.run_tracker,
+        batch=True,
+    )
+
+    shapes = [s.to_dict() for s in result.shapes]
+    return {
+        "shapes": shapes,
+        "replace": result.replace,
+        "description": result.description,
+    }
+

--- a/anylabeling/services/auto_labeling/model_manager.py
+++ b/anylabeling/services/auto_labeling/model_manager.py
@@ -4,6 +4,10 @@ import time
 import yaml
 import importlib.resources as pkg_resources
 from threading import Lock
+import base64
+import requests
+import cv2
+import numpy as np
 
 from PyQt5.QtCore import QObject, QThread, pyqtSignal, pyqtSlot
 
@@ -13,6 +17,7 @@ from anylabeling.views.labeling.logger import logger
 from anylabeling.config import get_config, save_config
 from anylabeling.services.auto_labeling.types import AutoLabelingResult
 from anylabeling.services.auto_labeling.utils import TimeoutContext
+from anylabeling.views.labeling.shape import Shape
 from anylabeling.services.auto_labeling import (
     _CUSTOM_MODELS,
     _CACHED_AUTO_LABELING_MODELS,
@@ -44,6 +49,7 @@ class ModelManager(QObject):
 
     def __init__(self):
         super().__init__()
+        self.remote_api_url = os.environ.get("XANYLABELING_REMOTE_API")
         self.model_configs = []
 
         self.loaded_model_config = None
@@ -145,6 +151,9 @@ class ModelManager(QObject):
 
     def load_custom_model(self, config_file):
         """Run custom model loading in a thread"""
+        if self.remote_api_url:
+            self.load_model(config_file)
+            return True
         config_file = os.path.normpath(os.path.abspath(config_file))
         if (
             self.model_download_thread is not None
@@ -250,6 +259,31 @@ class ModelManager(QObject):
 
     def load_model(self, config_file):
         """Run model loading in a thread"""
+        if self.remote_api_url:
+            if not config_file:
+                self.unload_model()
+                self.new_model_status.emit(self.tr("No model selected."))
+                return
+            if config_file.startswith(":/"):
+                config_file_name = config_file[2:]
+                resource_path = pkg_resources.files(auto_labeling_configs).joinpath(
+                    "auto_labeling", config_file_name
+                )
+                with open(resource_path, "r", encoding="utf-8") as f:
+                    cfg = yaml.safe_load(f)
+            else:
+                with open(config_file, "r", encoding="utf-8") as f:
+                    cfg = yaml.safe_load(f)
+            self.loaded_model_config = {
+                "name": cfg.get("name"),
+                "display_name": cfg.get("display_name", cfg.get("name")),
+                "config_file": config_file,
+            }
+            self.new_model_status.emit(
+                self.tr("Selected remote model: {name}").format(name=self.loaded_model_config["display_name"])
+            )
+            self.model_loaded.emit(self.loaded_model_config)
+            return
         if (
             self.model_download_thread is not None
             and self.model_download_thread.isRunning()
@@ -1946,6 +1980,51 @@ class ModelManager(QObject):
             self.new_model_status.emit(
                 self.tr("Model is not loaded. Choose a mode to continue.")
             )
+            self.prediction_finished.emit()
+            return
+
+        if self.remote_api_url:
+            try:
+                _, buffer = cv2.imencode(".jpg", image)
+                img_b64 = base64.b64encode(buffer.tobytes()).decode("utf-8")
+                payload = {
+                    "model": self.loaded_model_config["name"],
+                    "image": img_b64,
+                    "filename": filename,
+                    "run_tracker": run_tracker,
+                }
+                if text_prompt is not None:
+                    payload["text_prompt"] = text_prompt
+                resp = requests.post(
+                    f"{self.remote_api_url.rstrip('/')}/predict",
+                    json=payload,
+                    timeout=60,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                shapes = []
+                for s in data.get("shapes", []):
+                    shape = Shape()
+                    shape.load_from_dict(s)
+                    shapes.append(shape)
+                auto_labeling_result = AutoLabelingResult(
+                    shapes,
+                    replace=data.get("replace", True),
+                    description=data.get("description", ""),
+                )
+                if batch:
+                    return auto_labeling_result
+                else:
+                    self.new_auto_labeling_result.emit(auto_labeling_result)
+                    self.new_model_status.emit(
+                        self.tr("Finished inferencing AI model. Check the result.")
+                    )
+            except Exception as e:
+                logger.error(f"Error in remote predict_shapes: {e}")
+                template = "Error in model prediction: {error_message}"
+                translated_template = self.tr(template)
+                error_text = translated_template.format(error_message=str(e))
+                self.new_model_status.emit(error_text)
             self.prediction_finished.emit()
             return
 

--- a/anylabeling/services/auto_labeling/model_manager.py
+++ b/anylabeling/services/auto_labeling/model_manager.py
@@ -46,6 +46,7 @@ class ModelManager(QObject):
     prediction_finished = pyqtSignal()
     request_next_files_requested = pyqtSignal()
     output_modes_changed = pyqtSignal(dict, str)
+    remote_api_changed = pyqtSignal(str)
 
     def __init__(self):
         super().__init__()
@@ -61,6 +62,18 @@ class ModelManager(QObject):
         self.model_execution_thread_lock = Lock()
 
         self.load_model_configs()
+
+    def set_remote_api_url(self, url: str | None):
+        """Set the remote API endpoint used for inference."""
+        if url:
+            url = url.strip()
+        self.remote_api_url = url or None
+        if self.remote_api_url:
+            os.environ["XANYLABELING_REMOTE_API"] = self.remote_api_url
+        else:
+            os.environ.pop("XANYLABELING_REMOTE_API", None)
+        self.unload_model()
+        self.remote_api_changed.emit(self.remote_api_url or "")
 
     def load_model_configs(self):
         """Load model configs"""
@@ -1961,8 +1974,21 @@ class ModelManager(QObject):
     def unload_model(self):
         """Unload model"""
         if self.loaded_model_config is not None:
-            self.loaded_model_config["model"].unload()
+            try:
+                self.loaded_model_config["model"].unload()
+            except Exception:
+                pass
             self.loaded_model_config = None
+            try:
+                import gc
+
+                gc.collect()
+                import torch
+
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+            except Exception:
+                pass
 
     def predict_shapes(
         self,

--- a/anylabeling/views/labeling/label_widget.py
+++ b/anylabeling/views/labeling/label_widget.py
@@ -53,6 +53,7 @@ from .widgets import (
     DigitShortcutDialog,
     LabelModifyDialog,
     GroupIDModifyDialog,
+    RemoteServerDialog,
     OverviewDialog,
     SearchBar,
     ToolBar,
@@ -718,6 +719,12 @@ class LabelingWidget(LabelDialog):
             shortcuts["edit_group_id"],
             icon="edit",
             tip=self.tr("Manage Group ID"),
+        )
+        remote_server = action(
+            self.tr("&Remote Server"),
+            self.set_remote_server,
+            icon=None,
+            tip=self.tr("Configure remote inference server"),
         )
         union_selection = action(
             self.tr("&Union Selection"),
@@ -1530,6 +1537,7 @@ class LabelingWidget(LabelDialog):
                 digit_shortcut_manager,
                 label_manager,
                 gid_manager,
+                remote_server,
                 None,
                 hbb_to_obb,
                 obb_to_hbb,
@@ -2213,6 +2221,20 @@ class LabelingWidget(LabelDialog):
         result = modify_gid_dialog.exec_()
         if result == QtWidgets.QDialog.Accepted:
             self.load_file(self.filename)
+
+    def set_remote_server(self):
+        dialog = RemoteServerDialog(
+            parent=self,
+            current_url=self._config.get(
+                "remote_api_url", os.environ.get("XANYLABELING_REMOTE_API", "")
+            ),
+        )
+        result = dialog.exec_()
+        if result == QtWidgets.QDialog.Accepted:
+            url = dialog.get_url()
+            self._config["remote_api_url"] = url or None
+            save_config(self._config)
+            self.auto_labeling_widget.model_manager.set_remote_api_url(url)
 
     def open_chatbot(self):
         dialog = ChatbotDialog(self)

--- a/anylabeling/views/labeling/utils/__init__.py
+++ b/anylabeling/views/labeling/utils/__init__.py
@@ -1,6 +1,10 @@
 # flake8: noqa
 
-from .batch import run_all_images
+def run_all_images(*args, **kwargs):
+    """Lazy import to avoid heavy dependencies during module import."""
+    from .batch import run_all_images as _run_all_images
+
+    return _run_all_images(*args, **kwargs)
 from .colormap import label_colormap
 from .crop import save_crop
 from .export import (

--- a/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.py
+++ b/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.py
@@ -51,6 +51,7 @@ class AutoLabelingWidget(QWidget):
         uic.loadUi(os.path.join(current_dir, "auto_labeling.ui"), self)
 
         self.model_manager = ModelManager()
+        self.model_manager.set_remote_api_url(parent._config.get("remote_api_url"))
         self.model_manager.new_model_status.connect(self.on_new_model_status)
         self.new_model_selected.connect(self.model_manager.load_model)
         self.new_custom_model_selected.connect(

--- a/anylabeling/views/labeling/widgets/remote_server_dialog.py
+++ b/anylabeling/views/labeling/widgets/remote_server_dialog.py
@@ -1,0 +1,56 @@
+"""Dialog for configuring remote server URL."""
+
+from PyQt5.QtGui import QIcon
+from PyQt5.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QLabel,
+    QLineEdit,
+    QDialogButtonBox,
+)
+
+from anylabeling.views.labeling.utils.qt import new_icon
+from anylabeling.views.labeling.utils.style import (
+    get_lineedit_style,
+    get_ok_btn_style,
+    get_cancel_btn_style,
+)
+
+
+class RemoteServerDialog(QDialog):
+    """Allows the user to enter a remote server URL."""
+
+    def __init__(self, parent=None, current_url: str = ""):
+        super().__init__(parent)
+        self.setWindowTitle(self.tr("Set Remote Server"))
+        self.setMinimumWidth(500)
+
+        layout = QVBoxLayout(self)
+
+        label = QLabel(self.tr("Enter remote server URL:"))
+        layout.addWidget(label)
+
+        self.url_input = QLineEdit(current_url)
+        self.url_input.setPlaceholderText(self.tr("e.g. http://host:8000"))
+        self.url_input.setStyleSheet(get_lineedit_style())
+        layout.addWidget(self.url_input)
+
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
+        ok_button = button_box.button(QDialogButtonBox.Ok)
+        cancel_button = button_box.button(QDialogButtonBox.Cancel)
+        if ok_button:
+            ok_button.setStyleSheet(get_ok_btn_style())
+            ok_button.setIcon(QIcon())
+        if cancel_button:
+            cancel_button.setStyleSheet(get_cancel_btn_style())
+            cancel_button.setIcon(QIcon())
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+    def get_url(self) -> str:
+        """Return the entered URL."""
+        return self.url_input.text().strip()
+


### PR DESCRIPTION
## Summary
- add FastAPI server for remote model execution
- support remote server via `XANYLABELING_REMOTE_API` env in `ModelManager`
- document new server mode in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_6842e875e67c8333ac53c490adad0252